### PR TITLE
Draft: 1st downgrade of lofts and sweep should be de-parametrization

### DIFF
--- a/src/Mod/Draft/draftfunctions/downgrade.py
+++ b/src/Mod/Draft/draftfunctions/downgrade.py
@@ -390,7 +390,11 @@ def downgrade(objects, delete=False, force=None):
         # special case, we have one parametric object: we "de-parametrize" it
         elif len(objects) == 1 \
                 and hasattr(objects[0], "Shape") \
-                and (hasattr(objects[0], "Base") or hasattr(objects[0], "Profile")):
+                and (
+                    hasattr(objects[0], "Base")
+                    or hasattr(objects[0], "Profile")
+                    or hasattr(objects[0], "Sections")
+                ):
             result = _shapify(objects[0])
             if result:
                 _msg(translate("draft", "Found 1 parametric object: breaking its dependencies"))


### PR DESCRIPTION
Part Lofts and Sweeps were not recognized as parametric objects and therefore immediately split into faces instead of being de-parametrized first.

Forum topic:
https://forum.freecad.org/viewtopic.php?t=98271