### PR TITLE
BIM: ArchProfile: rename OutDiameter to OutsideDiameter and prop group Draft to Profile

### DIFF
--- a/src/Mod/BIM/ArchProfile.py
+++ b/src/Mod/BIM/ArchProfile.py
@@ -110,11 +110,38 @@ class _Profile(Draft._DraftObject):
             self.Profile = state
         self.Type = "Profile"
 
+    def onDocumentRestored(self, obj):
+        """Rename property OutDiameter to OutsideDiameter and rename property group Draft to Profile"""
+
+        if hasattr(obj, "OutDiameter"):
+            # 1v1 to 1v2 changes
+            obj.setPropertyStatus("OutDiameter", "-LockDynamic")
+            obj.renameProperty("OutDiameter", "OutsideDiameter")
+            obj.setPropertyStatus("OutsideDiameter", "LockDynamic")
+            if obj.getGroupOfProperty("OutsideDiameter") == "Draft":
+                self._update_propgroup_1v1_to_1v2(obj)
+            self.execute(obj)  # to use Part::FaceMakerCheese for the face
+            return
+        for prop in ("Height", "Size"):
+            # profiles other than the circular tubeprofile have either a Height or Size property
+            if hasattr(obj, prop) and obj.getGroupOfProperty(prop) == "Draft":
+                self._update_propgroup_1v1_to_1v2(obj)
+                return
+
+    def _update_propgroup_1v1_to_1v2(self, obj):
+        """Helper function to rename property group Draft to Profile"""
+
+        for prop in obj.PropertiesList:
+            if obj.getGroupOfProperty(prop) == "Draft":
+                obj.setPropertyStatus(prop, "-LockDynamic")
+                obj.setGroupOfProperty(prop, "Profile")
+                obj.setPropertyStatus(prop, "LockDynamic")
+
     def cleanProperties(self, obj):
         """Remove all Profile properties"""
 
         for prop in obj.PropertiesList:
-            if obj.getGroupOfProperty(prop) == "Draft":
+            if obj.getGroupOfProperty(prop) == "Profile":
                 obj.setPropertyStatus(prop, "-LockDynamic")
                 obj.removeProperty(prop)
 
@@ -126,15 +153,15 @@ class _ProfileC(_Profile):
         self.cleanProperties(obj)
         obj.addProperty(
             "App::PropertyLength",
-            "OutDiameter",
-            "Draft",
-            QT_TRANSLATE_NOOP("App::Property", "Outside Diameter"),
+            "OutsideDiameter",
+            "Profile",
+            QT_TRANSLATE_NOOP("App::Property", "Outside diameter"),
             locked=True,
-        ).OutDiameter = profile[4]
+        ).OutsideDiameter = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "Thickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Wall thickness"),
             locked=True,
         ).Thickness = profile[5]
@@ -144,8 +171,8 @@ class _ProfileC(_Profile):
         import Part
 
         pl = obj.Placement
-        c1 = Part.makeCircle(obj.OutDiameter.Value / 2)
-        c2 = Part.makeCircle(obj.OutDiameter.Value / 2 - obj.Thickness.Value)
+        c1 = Part.makeCircle(obj.OutsideDiameter.Value / 2)
+        c2 = Part.makeCircle(obj.OutsideDiameter.Value / 2 - obj.Thickness.Value)
         obj.Shape = Part.makeFace([c1, c2], "Part::FaceMakerCheese").Faces[0]
         obj.Placement = pl
 
@@ -158,28 +185,28 @@ class _ProfileH(_Profile):
         obj.addProperty(
             "App::PropertyLength",
             "Width",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Width of the beam"),
             locked=True,
         ).Width = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "Height",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Height of the beam"),
             locked=True,
         ).Height = profile[5]
         obj.addProperty(
             "App::PropertyLength",
             "WebThickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the web"),
             locked=True,
         ).WebThickness = profile[6]
         obj.addProperty(
             "App::PropertyLength",
             "FlangeThickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the flanges"),
             locked=True,
         ).FlangeThickness = profile[7]
@@ -220,14 +247,14 @@ class _ProfileR(_Profile):
         obj.addProperty(
             "App::PropertyLength",
             "Width",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Width of the beam"),
             locked=True,
         ).Width = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "Height",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Height of the beam"),
             locked=True,
         ).Height = profile[5]
@@ -254,21 +281,21 @@ class _ProfileRH(_Profile):
         obj.addProperty(
             "App::PropertyLength",
             "Width",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Width of the beam"),
             locked=True,
         ).Width = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "Height",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Height of the beam"),
             locked=True,
         ).Height = profile[5]
         obj.addProperty(
             "App::PropertyLength",
             "Thickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the sides"),
             locked=True,
         ).Thickness = profile[6]
@@ -314,28 +341,28 @@ class _ProfileU(_Profile):
         obj.addProperty(
             "App::PropertyLength",
             "Width",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Width of the beam"),
             locked=True,
         ).Width = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "Height",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Height of the beam"),
             locked=True,
         ).Height = profile[5]
         obj.addProperty(
             "App::PropertyLength",
             "WebThickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the webs"),
             locked=True,
         ).WebThickness = profile[6]
         obj.addProperty(
             "App::PropertyLength",
             "FlangeThickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the flange"),
             locked=True,
         ).FlangeThickness = profile[7]
@@ -374,21 +401,21 @@ class _ProfileL(_Profile):
         obj.addProperty(
             "App::PropertyLength",
             "Width",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Width of the beam"),
             locked=True,
         ).Width = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "Height",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Height of the beam"),
             locked=True,
         ).Height = profile[5]
         obj.addProperty(
             "App::PropertyLength",
             "Thickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the legs"),
             locked=True,
         ).Thickness = profile[6]
@@ -421,28 +448,28 @@ class _ProfileT(_Profile):
         obj.addProperty(
             "App::PropertyLength",
             "Width",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Width of the beam"),
             locked=True,
         ).Width = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "Height",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Height of the beam"),
             locked=True,
         ).Height = profile[5]
         obj.addProperty(
             "App::PropertyLength",
             "WebThickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the web"),
             locked=True,
         ).WebThickness = profile[6]
         obj.addProperty(
             "App::PropertyLength",
             "FlangeThickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the flanges"),
             locked=True,
         ).FlangeThickness = profile[7]
@@ -475,56 +502,56 @@ class _ProfileTSLOT(_Profile):
         obj.addProperty(
             "App::PropertyLength",
             "Size",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Overall size"),
             locked=True,
         ).Size = profile[4]
         obj.addProperty(
             "App::PropertyLength",
             "SlotSize",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Slot size"),
             locked=True,
         ).SlotSize = profile[5]
         obj.addProperty(
             "App::PropertyLength",
             "WallThickness",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Thickness of the wall"),
             locked=True,
         ).WallThickness = profile[6]
         obj.addProperty(
             "App::PropertyLength",
             "TnutSlotWidth",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "T-nut slot width"),
             locked=True,
         ).TnutSlotWidth = profile[7]
         obj.addProperty(
             "App::PropertyLength",
             "TnutSlotDepth",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "T-nut slot depth"),
             locked=True,
         ).TnutSlotDepth = profile[8]
         obj.addProperty(
             "App::PropertyLength",
             "CoreSize",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Internal core size"),
             locked=True,
         ).CoreSize = profile[9]
         obj.addProperty(
             "App::PropertyLength",
             "HoleDiameter",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Internal hole diameter"),
             locked=True,
         ).HoleDiameter = profile[10]
         obj.addProperty(
             "App::PropertyLength",
             "FilletRadius",
-            "Draft",
+            "Profile",
             QT_TRANSLATE_NOOP("App::Property", "Corner fillet radius"),
             locked=True,
         ).FilletRadius = profile[11]


### PR DESCRIPTION
Supersedes #18533.

Renamed the property 'OutDiameter' to 'OutsideDiameter' and the property group 'Draft' to 'Profile'. Implemented the `onDocumentRestored` function to handle older files.